### PR TITLE
Fix sitemap not having proper URLs for locales

### DIFF
--- a/app/views/home/index.xml.erb
+++ b/app/views/home/index.xml.erb
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:geo="http://www.google.com/geo/schemas/sitemap/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
-    <loc><%= home_url(:en) %></loc>
+    <loc><%= root_url %></loc>
     <changefreq>daily</changefreq>
   </url>
-  <url>
-    <loc><%= home_url(:br) %></loc>
-    <changefreq>daily</changefreq>
-  </url>
+  <% I18n.available_locales.each do |locale| %>
+    <url>
+      <loc><%= home_url(locale) %></loc>
+      <changefreq>daily</changefreq>
+    </url>
+  <% end %>
 </urlset>


### PR DESCRIPTION
## Description
Google Search Console pointed out that the current sitemap was pointing to an older version of portuguese version of website. This PR fixes this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
