### PR TITLE
Manually install wkhtmltopdf instead of using wkhtmltopdf-binary gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,15 @@ ENV RAILS_ENV="production" \
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-  apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+  apt-get install --no-install-recommends -y curl wget libvips postgresql-client && \
+  # dependencies for wkhtmltopdf
+  apt-get install --no-install-recommends -y xfonts-base xfonts-75dpi && \
+  # / dependencies for wkhtmltopdf
   rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# install wkhtmltopdf
+RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_arm64.deb
+RUN apt install ./wkhtmltox_0.12.6.1-3.bookworm_arm64.deb
 
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
@@ -68,8 +75,15 @@ ENV RAILS_ENV="development"
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-  apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+  apt-get install --no-install-recommends -y curl wget libvips postgresql-client && \
+  # dependencies for wkhtmltopdf
+  apt-get install --no-install-recommends -y xfonts-base xfonts-75dpi && \
+  # / dependencies for wkhtmltopdf
   rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# install wkhtmltopdf
+RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_arm64.deb
+RUN apt install ./wkhtmltox_0.12.6.1-3.bookworm_arm64.deb
 
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'draper'
 gem 'importmap-rails'
 gem 'sprockets-rails'
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'
 
 # Admin gems
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,6 @@ GEM
     websocket-extensions (0.1.5)
     wicked_pdf (2.7.0)
       activesupport
-    wkhtmltopdf-binary (0.12.6.6)
     zeitwerk (2.6.12)
 
 PLATFORMS
@@ -375,7 +374,6 @@ DEPENDENCIES
   sprockets-rails
   turbo-rails
   wicked_pdf
-  wkhtmltopdf-binary
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
wkhtmltopdf is deprecated and wkhtmltopdf-binary gem does not have a proper debian12 binary file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintentance (update dependencies of the project)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
