### PR TITLE
Build development and production images to be sure they are good to release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: test
+      publish:
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build:
@@ -33,7 +37,7 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: ${{ inputs.publish }}
           context: .
           target: ${{ inputs.target }}
           tags: ${{ inputs.tag-name }}:${{ inputs.target }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,22 @@ jobs:
     with:
       target: cypress
 
+  development:
+    name: Development
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit
+    with:
+      target: development
+      publish: false
+
+  production:
+    name: Production
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit
+    with:
+      target: production
+      publish: false
+
   rubocop:
     name: Rubocop
     uses: ./.github/workflows/lint.yml


### PR DESCRIPTION
## Description
There is a potential weak spot on ruby updates introduced on #1120 and #1121. It is better to build `development` and `production` images to be sure they are usable after merge. These images should not be published until PR is merged

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintentance (update dependencies of the project)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
