### PR TITLE
Deploy to preview using docker instead of regular builds

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -6,7 +6,7 @@ on:
       tag-name:
         type: string
         required: false
-        default: "gmmcal/gmmcal"
+        default: "gmmcal/gmmcal:test"
       target:
         type: string
         required: false
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    name: 'Build Image'
+    name: "Build Image"
     runs-on: ubuntu-20.04
 
     steps:
@@ -40,6 +40,6 @@ jobs:
           push: ${{ inputs.publish }}
           context: .
           target: ${{ inputs.target }}
-          tags: ${{ inputs.tag-name }}:${{ inputs.target }}
+          tags: ${{ inputs.tag-name }}
           cache-from: type=registry,ref=gmmcal/gmmcal:buildcache${{ inputs.target }}
           cache-to: type=registry,ref=gmmcal/gmmcal:buildcache${{ inputs.target }},mode=max

--- a/.github/workflows/_preview.yml
+++ b/.github/workflows/_preview.yml
@@ -1,0 +1,21 @@
+name: Deploy preview image
+
+on:
+  workflow_call:
+    inputs:
+      tag-name:
+        type: string
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.result.outputs.url }}
+    steps:
+      - name: Create Render service preview
+        id: result
+        run: |
+          curl -X POST https://api.render.com/v1/services/srv-${{ secrets.DEPLOY_SERVICE }}/preview -H 'Authorization: Bearer ${{ secrets.RENDER_API_KEY }}' -H 'Accept: application/json' -d '{"imagePath": "docker.io/${{ inputs.tag-name }}", "name": "gustavocunha-preview-pr-${{ github.event.number }}-${{ github.run_number }}"}' > result.json
+          echo "url=$(jq -r '.service.serviceDetails.url' result.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,17 @@
+name: Cleanup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Remove preview environments that are older than 7 days
+      - name: Cleanup stale preview environments
+        run: |
+          curl https://api.render.com/v1/services -H 'Authorization: Bearer ${{ secrets.RENDER_API_KEY }}' -H 'Accept: application/json' | \
+          jq -r '.[].service | select(.name | contains("gustavocunha-preview-pr-")) | select(.updatedAt <= (now|strftime("%Y-%m-%dT%H:%M:%SZ") | fromdate - (7*24*60*60)|strftime("%Y-%m-%dT%H:%M:%Z"))) | .id' | \
+          xargs -IID curl -X DELETE https://api.render.com/v1/services/ID -H 'Authorization: Bearer ${{ secrets.RENDER_API_KEY }}' -H 'Accept: application/json'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           DEPLOY_SERVICE: ${{ secrets.DEPLOY_SERVICE }}
         run: |
-          curl -v "https://api.render.com/deploy/srv-$DEPLOY_SERVICE?key=$DEPLOY_KEY"
+          curl "https://api.render.com/deploy/srv-$DEPLOY_SERVICE?key=$DEPLOY_KEY"
 
   deploy_production:
     name: 'Deploy: Production'
@@ -56,4 +56,4 @@ jobs:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           DEPLOY_SERVICE: ${{ secrets.DEPLOY_SERVICE }}
         run: |
-          curl -v "https://api.render.com/deploy/srv-$DEPLOY_SERVICE?key=$DEPLOY_KEY"
+          curl "https://api.render.com/deploy/srv-$DEPLOY_SERVICE?key=$DEPLOY_KEY"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   - pull_request
 
 jobs:
+  # DOCKER
   build:
     name: Test
     uses: ./.github/workflows/_docker.yml
@@ -15,6 +16,16 @@ jobs:
     secrets: inherit
     with:
       target: cypress
+      tag-name: "gmmcal/gmmcal:cypress"
+
+  preview:
+    name: Preview
+    uses: ./.github/workflows/_docker.yml
+    secrets: inherit
+    with:
+      target: production
+      tag-name: "gmmcal/gmmcal:preview-${{ github.event.number }}-${{ github.run_number }}"
+      publish: true
 
   development:
     name: Development
@@ -32,6 +43,7 @@ jobs:
       target: production
       publish: false
 
+  # LINT
   rubocop:
     name: Rubocop
     uses: ./.github/workflows/_lint.yml
@@ -60,27 +72,6 @@ jobs:
       command: bundle exec scss-lint --config .scss-lint.yml
     needs: build
 
-  tests:
-    name: Backend
-    uses: ./.github/workflows/_tests.yml
-    with:
-      command: bundle exec rspec
-    needs: build
-
-  e2e-admin:
-    name: Admin
-    uses: ./.github/workflows/_cypress.yml
-    with:
-      pattern: spec/end-to-end/tests/admin/**.js
-    needs: [build, cypress]
-
-  e2e-frontend:
-    name: Frontend
-    uses: ./.github/workflows/_cypress.yml
-    with:
-      pattern: spec/end-to-end/tests/frontend/**.js
-    needs: [build, cypress]
-
   bundler-audit:
     name: Bundler Audit
     uses: ./.github/workflows/_lint.yml
@@ -103,3 +94,34 @@ jobs:
       command: yarn eslint:tests
       image: gmmcal/gmmcal:cypress
     needs: cypress
+
+  # TESTS
+  tests:
+    name: Backend
+    uses: ./.github/workflows/_tests.yml
+    with:
+      command: bundle exec rspec
+    needs: build
+
+  e2e-admin:
+    name: Admin
+    uses: ./.github/workflows/_cypress.yml
+    with:
+      pattern: spec/end-to-end/tests/admin/**.js
+    needs: [build, cypress]
+
+  e2e-frontend:
+    name: Frontend
+    uses: ./.github/workflows/_cypress.yml
+    with:
+      pattern: spec/end-to-end/tests/frontend/**.js
+    needs: [build, cypress]
+
+  # Preview and Cleanup
+  deploy:
+    name: Preview
+    uses: ./.github/workflows/_preview.yml
+    needs: preview
+    secrets: inherit
+    with:
+      tag-name: "gmmcal/gmmcal:preview-${{ github.event.number }}-${{ github.run_number }}"

--- a/render.yaml
+++ b/render.yaml
@@ -53,21 +53,6 @@ services:
           name: gustavocunha-staging
           property: connectionString
       - fromGroup: staging
-  - type: web
-    name: gustavocunha-prs
-    env: ruby
-    buildCommand: "bundle install; bundle exec rake assets:precompile; bundle exec rake assets:clean; bundle exec rake db:migrate db:seed:all db:cache:clear;"
-    startCommand: "bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-production}"
-    autoDeploy: true
-    pullRequestPreviewsEnabled: true
-    plan: free
-    region: frankfurt
-    envVars:
-      - key: DATABASE_URL
-        fromDatabase:
-          name: gustavocunha-staging
-          property: connectionString
-      - fromGroup: staging
   - type: redis
     name: gustavocunha
     ipAllowList: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move away from preview environments being created by render.com and take control over it. This means that we need to create PR server and also cleanup.

## Motivation and Context
In order to make process smoother, I will deploy all preview environments using a docker image built just like production one and deploy it to a newly created preview environment.

After 7 days, all non-updated preview environments should be deleted from render.com. For now, there is no action on removing preview docker images from docker.io. This might be done manually for now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintentance (update dependencies of the project)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
