### PR TITLE
Enforce a specific minimal ruby at all times instead only on prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Enforce minimum ruby version
-ruby '3.3' if ENV.fetch('RAILS_ENV', nil) == 'production'
+ruby '~> 3.3.1'
 
 # Application gems
 # Use bootsnap to improve performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,5 +416,8 @@ DEPENDENCIES
   sprockets-rails
   turbo-rails
 
+RUBY VERSION
+   ruby 3.3.1p55
+
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
## Description
Preview environments were failing to deploy because version `3.3.1` of ruby was not compatible with constraint `ruby '3.3'` present on `Gemfile`. This change makes it more flexible to patch changes, ensuring a minimal version is used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Maintentance (update dependencies of the project)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
