### PR TITLE
NEW: Improve concurrency on deploy job to avoid tags being on incorrect place

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
 
-concurrency:
-  group: deploy
-  cancel-in-progress: false
-
 jobs:
   tag:
     name: "Tag: Production"
     uses: gmmcal/gmmcal-reusable-workflows/.github/workflows/_tag.yml@v0
+    concurrency:
+      group: tag
+      cancel-in-progress: false
+    with:
+      reference: ${{ github.sha }}
 
   release:
     name: Release
@@ -38,6 +39,9 @@ jobs:
     name: Build
     uses: gmmcal/gmmcal-reusable-workflows/.github/workflows/_docker.yml@v0
     secrets: inherit
+    concurrency:
+      group: build-development
+      cancel-in-progress: true
     with:
       name: Development
       target: development


### PR DESCRIPTION
## Description
In order to avoid merges on `main` to pile and tag job fail because it can't determine proper version because a previous job tagged the wrong `sha`, I want to limit the tag workflow to run on a specific commit reference and avoid concurrency on it. 

Along with this, since the `development` image is always using latest master, we can stop build job and trigger a new one using latest merge

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintentance (update dependencies of the project)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
